### PR TITLE
obj-flatten 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obj-flatten",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Convert nested objects in flatten ones.",
   "main": "lib/index.js",
   "directories": {
@@ -46,6 +46,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.