### PR TITLE
Pass separator along when recursing (fixes #4)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ module.exports = function flattenObject (obj, del) {
     iterateObject(obj, (value, key) => {
         typpy(value, Object)
             ? iterateObject(
-                  flattenObject(value)
+                  flattenObject(value, del)
                 , (flatValue, xkey) => result[key + del + xkey] = flatValue
               )
             : result[key] = obj[key]


### PR DESCRIPTION
fixes https://github.com/IonicaBizau/obj-flatten/issues/4