### PR TITLE
#8 Return a string when flattening a string, instead of returning {}

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const iterateObject = require("iterate-object")
  * @return {Object} Flatten object
  */
 module.exports = function flattenObject (obj, del) {
-
+    if (typpy(obj, String)) return obj;
     let result = {};
     del = del || ".";
 

--- a/test/index.js
+++ b/test/index.js
@@ -62,3 +62,8 @@ test('separator', function (t) {
   });
   t.end();
 })
+
+test('strings', function (t) {
+  t.deepEqual(flatten('some string'), 'some string', 'string value at root');
+  t.end();
+})


### PR DESCRIPTION
This PR changes how strings are treated when passed to `obj-flatten`.

Given:
```js
const flatten = require('obj-flatten');
flatten('some string');
```

Used to produce:
```js
{}
```

But now produces:
```js
'some string'
```